### PR TITLE
Password Checker exercise

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,12 +1,18 @@
 import type { Config } from '@jest/types'
 
+const BaseDir = `<rootDir>/src/app/pass_checker`
+const BaseTestDir = `<rootDir>/src/test/pass_checker`
+
 const config: Config.InitialOptions = {
     preset: 'ts-jest',
     testEnvironment: 'node',
     verbose: true,
     collectCoverage: true,
     collectCoverageFrom: [
-        '<rootDir>/src/app/**/*.ts'
+        `${BaseDir}/**/*.ts`
+    ],
+    testMatch: [
+        `${BaseTestDir}/**/*.ts`
     ]
 }
 

--- a/src/app/pass_checker/PasswordChecker.ts
+++ b/src/app/pass_checker/PasswordChecker.ts
@@ -1,8 +1,36 @@
 
+export enum PasswordErrors {
+    SHORT = 'Password is too short',
+    NO_LOWER_CASE = 'Lower case letter required',
+    NO_UPPER_CASE = 'Upper case letter required'
+}
+
+export interface CheckResult {
+    valid: boolean,
+    reasons: string[]
+}
+
 export class PasswordChecker {
 
-    public checkpassword(){
+    public checkpassword(password: string): CheckResult {
+        const reasons:PasswordErrors[] = [];
 
+        if(password.length < 8) {
+            reasons.push(PasswordErrors.SHORT);
+        }
+
+        if(password === password.toLowerCase()) {
+            reasons.push(PasswordErrors.NO_UPPER_CASE);
+        }
+
+        if(password === password.toUpperCase()) {
+            reasons.push(PasswordErrors.NO_LOWER_CASE);
+        }
+        
+        return {
+            valid: reasons.length > 0 ? false : true,
+            reasons: reasons
+        }
     }
 
 }

--- a/src/app/pass_checker/PasswordChecker.ts
+++ b/src/app/pass_checker/PasswordChecker.ts
@@ -15,21 +15,31 @@ export class PasswordChecker {
     public checkpassword(password: string): CheckResult {
         const reasons:PasswordErrors[] = [];
 
-        if(password.length < 8) {
-            reasons.push(PasswordErrors.SHORT);
-        }
-
-        if(password === password.toLowerCase()) {
-            reasons.push(PasswordErrors.NO_UPPER_CASE);
-        }
-
-        if(password === password.toUpperCase()) {
-            reasons.push(PasswordErrors.NO_LOWER_CASE);
-        }
+        this.checkForLength(password, reasons);
+        this.checkForUpperCase(password, reasons);
+        this.checkForLowerCase(password, reasons);
         
         return {
             valid: reasons.length > 0 ? false : true,
             reasons: reasons
+        }
+    }
+
+    private checkForLength(password: string, reasons: PasswordErrors[]) {
+        if(password.length < 8) {
+            reasons.push(PasswordErrors.SHORT);
+        }
+    }
+
+    private checkForUpperCase(password: string, reasons: PasswordErrors[]) {
+        if(password === password.toLowerCase()) {
+            reasons.push(PasswordErrors.NO_UPPER_CASE);
+        }
+    }
+
+    private checkForLowerCase(password: string, reasons: PasswordErrors[]) {
+        if(password === password.toUpperCase()) {
+            reasons.push(PasswordErrors.NO_LOWER_CASE);
         }
     }
 

--- a/src/app/pass_checker/PasswordChecker.ts
+++ b/src/app/pass_checker/PasswordChecker.ts
@@ -2,17 +2,18 @@
 export enum PasswordErrors {
     SHORT = 'Password is too short',
     NO_LOWER_CASE = 'Lower case letter required',
-    NO_UPPER_CASE = 'Upper case letter required'
+    NO_UPPER_CASE = 'Upper case letter required',
+    NO_NUMBER = 'At least one number is required'
 }
 
 export interface CheckResult {
     valid: boolean,
-    reasons: string[]
+    reasons: PasswordErrors[]
 }
 
 export class PasswordChecker {
 
-    public checkpassword(password: string): CheckResult {
+    public checkPassword(password: string): CheckResult {
         const reasons:PasswordErrors[] = [];
 
         this.checkForLength(password, reasons);
@@ -22,6 +23,22 @@ export class PasswordChecker {
         return {
             valid: reasons.length > 0 ? false : true,
             reasons: reasons
+        }
+    }
+
+    public checkAdminPassword(password: string): CheckResult {
+        const basicCheck = this.checkPassword(password);
+        this.checkForNumber(password, basicCheck.reasons);
+        return {
+            valid: basicCheck.reasons.length > 0 ? false: true,
+            reasons: basicCheck.reasons
+        }
+    }
+
+    public checkForNumber(password: string, reasons: PasswordErrors[]){
+        const hasNumber = /\d/;
+        if(!hasNumber.test(password)){
+            reasons.push(PasswordErrors.NO_NUMBER);
         }
     }
 

--- a/src/app/pass_checker/PasswordChecker.ts
+++ b/src/app/pass_checker/PasswordChecker.ts
@@ -1,0 +1,8 @@
+
+export class PasswordChecker {
+
+    public checkpassword(){
+
+    }
+
+}

--- a/src/test/pass_checker/PasswordChecker.test.ts
+++ b/src/test/pass_checker/PasswordChecker.test.ts
@@ -1,4 +1,4 @@
-import { PasswordChecker } from "../../app/pass_checker/PasswordChecker";
+import { PasswordErrors, PasswordChecker } from "../../app/pass_checker/PasswordChecker";
 
 
 describe('Password checker', ()=>{
@@ -9,7 +9,44 @@ describe('Password checker', ()=>{
         sut = new PasswordChecker ();
     })
 
-    it('Should do nothing', ()=>{
-        sut.checkpassword();
-    })
+    it('Password with less than 8 chars is invalid', ()=>{
+        const actual = sut.checkpassword('1234567');
+        expect(actual.valid).toBe(false);
+        expect(actual.reasons).toContain(PasswordErrors.SHORT);
+    });
+
+    it('Password with more than 8 chars is valid', ()=>{
+        const actual = sut.checkpassword('123456789');
+        expect(actual.valid).toBe(false);
+        expect(actual.reasons).not.toContain(PasswordErrors.SHORT);
+    });
+
+    it('Password with no upper case is invalid', ()=>{
+        const actual = sut.checkpassword('abcd');
+        expect(actual.valid).toBe(false);
+        expect(actual.reasons).toContain(PasswordErrors.NO_UPPER_CASE);
+    });
+
+    it('Password with an upper case is valid', ()=>{
+        const actual = sut.checkpassword('ABC');
+        expect(actual.valid).toBe(false);
+        expect(actual.reasons).not.toContain(PasswordErrors.NO_UPPER_CASE);
+    });
+
+    it('Password with no lower case is invalid', ()=>{
+        const actual = sut.checkpassword('ABCD');
+        expect(actual.valid).toBe(false);
+        expect(actual.reasons).toContain(PasswordErrors.NO_LOWER_CASE);
+    });
+
+    it('Password with lower case is valid', ()=>{
+        const actual = sut.checkpassword('abcd');
+        expect(actual.valid).toBe(false);
+        expect(actual.reasons).not.toContain(PasswordErrors.NO_LOWER_CASE);
+    });
+    it('Complex Password is valid', ()=> {
+        const actual = sut.checkpassword('abc123DEF');
+        expect(actual.valid).toBe(true);
+        expect(actual.reasons.length);
+    });
 })

--- a/src/test/pass_checker/PasswordChecker.test.ts
+++ b/src/test/pass_checker/PasswordChecker.test.ts
@@ -1,0 +1,15 @@
+import { PasswordChecker } from "../../app/pass_checker/PasswordChecker";
+
+
+describe('Password checker', ()=>{
+
+    let sut: PasswordChecker
+
+    beforeEach(()=>{
+        sut = new PasswordChecker ();
+    })
+
+    it('Should do nothing', ()=>{
+        sut.checkpassword();
+    })
+})

--- a/src/test/pass_checker/PasswordChecker.test.ts
+++ b/src/test/pass_checker/PasswordChecker.test.ts
@@ -10,43 +10,55 @@ describe('Password checker', ()=>{
     })
 
     it('Password with less than 8 chars is invalid', ()=>{
-        const actual = sut.checkpassword('1234567');
+        const actual = sut.checkPassword('1234567');
         expect(actual.valid).toBe(false);
         expect(actual.reasons).toContain(PasswordErrors.SHORT);
     });
 
     it('Password with more than 8 chars is valid', ()=>{
-        const actual = sut.checkpassword('123456789');
+        const actual = sut.checkPassword('123456789');
         expect(actual.valid).toBe(false);
         expect(actual.reasons).not.toContain(PasswordErrors.SHORT);
     });
 
     it('Password with no upper case is invalid', ()=>{
-        const actual = sut.checkpassword('abcd');
+        const actual = sut.checkPassword('abcd');
         expect(actual.valid).toBe(false);
         expect(actual.reasons).toContain(PasswordErrors.NO_UPPER_CASE);
     });
 
     it('Password with an upper case is valid', ()=>{
-        const actual = sut.checkpassword('ABC');
+        const actual = sut.checkPassword('ABC');
         expect(actual.valid).toBe(false);
         expect(actual.reasons).not.toContain(PasswordErrors.NO_UPPER_CASE);
     });
 
     it('Password with no lower case is invalid', ()=>{
-        const actual = sut.checkpassword('ABCD');
+        const actual = sut.checkPassword('ABCD');
         expect(actual.valid).toBe(false);
         expect(actual.reasons).toContain(PasswordErrors.NO_LOWER_CASE);
     });
 
     it('Password with lower case is valid', ()=>{
-        const actual = sut.checkpassword('abcd');
+        const actual = sut.checkPassword('abcd');
         expect(actual.valid).toBe(false);
         expect(actual.reasons).not.toContain(PasswordErrors.NO_LOWER_CASE);
     });
     it('Complex Password is valid', ()=> {
-        const actual = sut.checkpassword('abc123DEF');
+        const actual = sut.checkPassword('abc123DEF');
         expect(actual.valid).toBe(true);
-        expect(actual.reasons.length);
+        expect(actual.reasons).toHaveLength(0);
+    });
+
+    it('Admin Password must contain numbers', ()=> {
+        const actual = sut.checkAdminPassword('abcdABCD');
+        expect(actual.reasons).toContain(PasswordErrors.NO_NUMBER);
+        expect(actual.valid).toBe(false);
+    });
+
+    it('Admin Password with number is valid', ()=> {
+        const actual = sut.checkAdminPassword('abcdABCD7');
+        expect(actual.reasons).not.toContain(PasswordErrors.NO_NUMBER)
+        expect(actual.valid).toBe(true);
     });
 })


### PR DESCRIPTION
This adds a Password Checker exercise which is used to validate passwords to ensure they have a minimum complexity.  There are two types of passwords, `basic` and `admin`.  The `admin` passwords have the additional complexity requirement of needing at least one numeric character in addition to meeting all the requirements of the basic password.